### PR TITLE
Fix build reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     
     - CONDA_PY=27
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "SapKFao5+gLVVlTG9+xdC6FrL+SS3kWW7k+1P5wqY5www3rHQlLV64lDXwCnNe9tK4IF1/VLd+m5izvRObbVcjn50NxWVTq7/c8QglnRiHUfc2bp7t4MFo1QWHnAUM9jXVLT2vlPkyMI/FF5dh5rymZwTTHQQraSHeDKBy0L9AHxqu2ITWu45Caoz3i5+Muq4ratF6XpjqUKvunWYYco0AaTgIvoSSis9bB4+pUQ+IjJXGyPtkEAkvZ3KAKqrfD6NZms2xJb27AevwkWFEoVQx70mJIlrH4uY1uiZHbcu/jV5asBZr6qubHnjCiy5yma84Tper9KCVVlsGh8HoBpFeTF/Fr04uhicOzAawi/LTO6q+zfw3aqu+XKvoCY5cN+iUv7bPSDLzl2XjuzYslcae32V9relfRSuZ6KTLPsHSQkfopqUuR49rVovUKgTKqGSqqYcqeKli0SK1/MEDjEHEeS5stB4KEopOZpOESoYz5INkFA32XUg1vMcLRrmcd0WrzurkVmzN+Lq52P2YDWjB33w65o04S43Qa7azZYH4ZSVXpp/xyFh2E1oSE1GsVqeDzKxaIyfVB2Iun58T4i0VTxnvf3oyj27mtIuS2ybnp4mHX7Ouc7d2JQSEdyQGGnj50J4BoPmz8dmUjGoyHYn86fC7eDofqkp0loWSjFdFw="

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     
     - CONDA_PY=27
     - CONDA_PY=35
-    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "SapKFao5+gLVVlTG9+xdC6FrL+SS3kWW7k+1P5wqY5www3rHQlLV64lDXwCnNe9tK4IF1/VLd+m5izvRObbVcjn50NxWVTq7/c8QglnRiHUfc2bp7t4MFo1QWHnAUM9jXVLT2vlPkyMI/FF5dh5rymZwTTHQQraSHeDKBy0L9AHxqu2ITWu45Caoz3i5+Muq4ratF6XpjqUKvunWYYco0AaTgIvoSSis9bB4+pUQ+IjJXGyPtkEAkvZ3KAKqrfD6NZms2xJb27AevwkWFEoVQx70mJIlrH4uY1uiZHbcu/jV5asBZr6qubHnjCiy5yma84Tper9KCVVlsGh8HoBpFeTF/Fr04uhicOzAawi/LTO6q+zfw3aqu+XKvoCY5cN+iUv7bPSDLzl2XjuzYslcae32V9relfRSuZ6KTLPsHSQkfopqUuR49rVovUKgTKqGSqqYcqeKli0SK1/MEDjEHEeS5stB4KEopOZpOESoYz5INkFA32XUg1vMcLRrmcd0WrzurkVmzN+Lq52P2YDWjB33w65o04S43Qa7azZYH4ZSVXpp/xyFh2E1oSE1GsVqeDzKxaIyfVB2Iun58T4i0VTxnvf3oyj27mtIuS2ybnp4mHX7Ouc7d2JQSEdyQGGnj50J4BoPmz8dmUjGoyHYn86fC7eDofqkp0loWSjFdFw="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,14 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.
@@ -39,7 +47,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,14 +30,6 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
-    - TARGET_ARCH: x86
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,7 +43,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 2 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -52,6 +52,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {%set compress_type = "tar.gz" %}
 {%set hash_type = "sha256" %}
 {%set hash_val = "3b6e9a5f0484be0151f4106c5aba546eb3a382905ba69e86fa52ce5de95fed3f" %}
-{%set build_num = "1" %}
+{%set build_num = "2" %}
 
 package:
   name: {{ name|lower }}
@@ -22,16 +22,11 @@ requirements:
   build:
     - python
     - setuptools
-    - backports.ssl >=0.0.9
-    - mock ==1.3.0
-    - pyopenssl >=0.15.1
-    - six
-    - sphinx
 
   run:
     - python
     - backports.ssl >=0.0.9
-    - mock ==1.3.0
+    - mock ==1.3.0  # [py27]
     - pyopenssl >=0.15.1
     - six
     - sphinx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,16 @@ requirements:
   build:
     - python
     - setuptools
+    - six
+    - mock ==1.3.0  # [py27]
+    - sphinx
 
   run:
     - python
-    - backports.ssl >=0.0.9
-    - mock ==1.3.0  # [py27]
-    - pyopenssl >=0.15.1
     - six
-    - sphinx
+    - backports.ssl >=0.0.9  # [py27]
+    - mock ==1.3.0  # [py27]
+    - pyopenssl >=0.15.1  # [py27]
 
 test:
   imports:


### PR DESCRIPTION
Per setup.py, most of the build and run reqs used in imapclient should actually only be used in `py2k`. This patch strips out the unnecessary requirements.